### PR TITLE
Add user search, fix toast duplicates

### DIFF
--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -1,16 +1,30 @@
 // src/controllers/userController.js
 import User from '../models/User.js';
+import { Op } from 'sequelize';
 
 // GET /api/users — listado ordenado por createdAt
 export const getAllUsers = async (req, res) => {
   try {
+    const search = req.query.q || '';
+    const where = search
+      ? {
+          [Op.or]: [
+            { nombre: { [Op.like]: `%${search}%` } },
+            { email: { [Op.like]: `%${search}%` } }
+          ]
+        }
+      : undefined;
+
     const users = await User.findAll({
+      where,
       order: [['createdAt', 'DESC']],
-      attributes: ['id','nombre','email','rol','createdAt']
+      attributes: ['id', 'nombre', 'email', 'rol', 'createdAt']
     });
     res.json(users);
   } catch (err) {
-    res.status(500).json({ message: 'Error al obtener usuarios', error: err.message });
+    res
+      .status(500)
+      .json({ message: 'Error al obtener usuarios', error: err.message });
   }
 };
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,7 +2,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
-import { Toaster } from 'react-hot-toast'
 import App from './App.jsx'
 import { AuthProvider } from './Context/AuthContext.jsx'
 import './index.css'
@@ -12,23 +11,6 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     <BrowserRouter>
       <AuthProvider>
         <App />
-        <Toaster 
-          position="top-right"
-          toastOptions={{
-            duration: 4000,
-            style: {
-              background: '#363636',
-              color: '#fff',
-            },
-            success: {
-              duration: 3000,
-              theme: {
-                primary: 'green',
-                secondary: 'black',
-              },
-            },
-          }}
-        />
       </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>,

--- a/frontend/src/pages/UserManagement.jsx
+++ b/frontend/src/pages/UserManagement.jsx
@@ -7,6 +7,7 @@ import { usersApi } from '../Services/api'
 export default function UserManagement() {
   const [users, setUsers] = useState([])
   const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
   const [deleteModal, setDeleteModal] = useState({ show: false, id: null })
   const [editingUser, setEditingUser] = useState(null)
   const [formData, setFormData] = useState({
@@ -20,9 +21,9 @@ export default function UserManagement() {
     loadUsers()
   }, [])
 
-  const loadUsers = async () => {
+  const loadUsers = async (q = '') => {
     try {
-      const response = await usersApi.getAll()
+      const response = await usersApi.getAll(q)
       setUsers(response.data)
     } catch {
       toast.error('Error al cargar usuarios')
@@ -90,6 +91,34 @@ export default function UserManagement() {
       <Navbar />
       <div className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
         <h1 className="text-2xl font-bold mb-6">Gestión de Usuarios</h1>
+        <div className="mb-6 flex gap-2">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar por nombre o email"
+            className="px-3 py-2 rounded-md bg-gray-700 border-gray-600 text-gray-100 flex-1"
+          />
+          <button
+            onClick={() => {
+              setLoading(true)
+              loadUsers(search)
+            }}
+            className="px-4 py-2 bg-indigo-600 rounded text-white"
+          >
+            Buscar
+          </button>
+          <button
+            onClick={() => {
+              setSearch('')
+              setLoading(true)
+              loadUsers()
+            }}
+            className="px-4 py-2 bg-gray-600 rounded text-white"
+          >
+            Limpiar
+          </button>
+        </div>
 
         {/* Formulario */}
         <div className="bg-gray-800 shadow rounded-lg p-6 mb-6">

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -55,7 +55,7 @@ export const recordsApi = {
 
 // Servicios de Users
 export const usersApi = {
-  getAll: () => api.get('/api/users'),
+  getAll: (q = '') => api.get('/api/users', { params: { q } }),
   getById: (id) => api.get(`/api/users/${id}`),
   create: (data) => api.post('/api/users', data),
   update: (id, data) => api.put(`/api/users/${id}`, data),


### PR DESCRIPTION
## Summary
- support search parameter on GET /api/users
- expose search option in user management UI
- fix duplicate toast notifications by removing extra Toaster

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_6883ce7e2084832db8d4c2942402d749